### PR TITLE
feat: Implement language learning dashboard UI

### DIFF
--- a/poppa_frontend/src/app/[locale]/dashboard/page.tsx
+++ b/poppa_frontend/src/app/[locale]/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { AuthContext } from '../../../context/AuthContext'; // Adjust path as needed
 import { supabase } from '../../../lib/supabase'; // Adjust path as needed
+import { languages, Language } from '../../../lib/languageData';
 import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 
@@ -26,6 +27,7 @@ const DashboardPage = () => {
   const router = useRouter();
   const { t } = useTranslation();
 
+  const [selectedLanguage, setSelectedLanguage] = useState<Language>(languages[0]);
   const [subscription, setSubscription] = useState<Subscription | null>(null);
   const [usage, setUsage] = useState<Usage | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -194,6 +196,55 @@ const DashboardPage = () => {
             <p>{t('dashboard.usageDetails.loadingOrNotAvailable')}</p>
          </div>
        )}
+
+      {/* New Language Learning Section - Add this after existing content, inside the main container div */}
+      { user && subscription && (
+        <div className="mt-12 pt-8 border-t border-gray-200 dark:border-gray-700">
+          <h2 className="text-2xl font-bold mb-6 text-center md:text-left text-gray-800 dark:text-gray-200">{t('dashboard.learnNewLanguageTitle', 'Learn a New Language')}</h2>
+          <div className="flex flex-col md:flex-row gap-8">
+            {/* Sidebar */}
+            <div className="w-full md:w-1/4 bg-slate-50 dark:bg-slate-800 p-4 rounded-lg shadow-md">
+              <h3 className="text-lg font-semibold mb-4 text-slate-700 dark:text-slate-300">{t('dashboard.languagesTitle', 'Languages')}</h3>
+              <ul className="space-y-2">
+                {languages.map((lang) => (
+                  <li key={lang.name}>
+                    <button
+                      onClick={() => setSelectedLanguage(lang)}
+                      className={`w-full text-left px-4 py-2.5 rounded-md text-sm font-medium transition-colors duration-150 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-500
+                        ${
+                          selectedLanguage.name === lang.name
+                            ? 'bg-blue-600 text-white shadow-lg'
+                            : 'bg-white dark:bg-slate-700 text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-600'
+                        }`}
+                    >
+                      {lang.name}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            {/* Lesson Display */}
+            <div className="w-full md:w-3/4">
+              <h3 className="text-xl font-semibold mb-5 text-slate-800 dark:text-slate-200">
+                {selectedLanguage.name} {t('dashboard.lessonsTitleSuffix', 'Lessons')}
+              </h3>
+              {selectedLanguage && selectedLanguage.lessons && selectedLanguage.lessons.length > 0 ? (
+                <div className="space-y-4 max-h-[600px] overflow-y-auto pr-2 custom-scrollbar">
+                  {selectedLanguage.lessons.map((lesson, index) => (
+                    <div key={index} className="bg-white dark:bg-slate-700 p-4 rounded-lg shadow hover:shadow-lg transition-shadow duration-150 ease-in-out">
+                      <h4 className="text-md font-semibold text-blue-600 dark:text-blue-400">{lesson.title}</h4>
+                      <p className="text-sm text-slate-600 dark:text-slate-300 mt-1.5">{lesson.description}</p>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-slate-500 dark:text-slate-400 py-4">{t('dashboard.noLessonsAvailable', 'No lessons available for this language yet, or language data is loading.')}</p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/poppa_frontend/src/lib/languageData.ts
+++ b/poppa_frontend/src/lib/languageData.ts
@@ -1,0 +1,82 @@
+// poppa_frontend/src/lib/languageData.ts
+
+interface Lesson {
+  title: string;
+  description: string;
+}
+
+interface Language {
+  name: string;
+  lessons: Lesson[];
+}
+
+const generateLessons = (languageName: string, lessonCount: number): Lesson[] => {
+  const lessons: Lesson[] = [];
+  const commonTopics = [
+    "Basic Greetings & Introductions", "Alphabet & Pronunciation", "Numbers & Counting", "Common Nouns & Gender", "Basic Verbs (to be, to have)",
+    "Forming Simple Sentences", "Asking Questions", "Days of the Week & Months", "Colors & Shapes", "Family & Relationships",
+    "Food & Drinks", "Ordering at a Restaurant", "Shopping & Prices", "Directions & Getting Around", "Telling Time",
+    "Daily Routines", "Past Tense Basics", "Future Tense Basics", "Describing People & Things", "Hobbies & Interests",
+    "Weather & Seasons", "Travel & Holidays", "Making Appointments", "Expressing Opinions", "Comparisons & Superlatives",
+    "Basic Prepositions", "Common Adjectives", "Common Adverbs", "Cultural Etiquette", "Idiomatic Expressions (Beginner)",
+    "Reading Short Stories", "Writing Simple Paragraphs", "Listening Comprehension (Easy Dialogues)", "Speaking Practice (Role-playing)", "Review & Consolidation Part 1",
+    "Intermediate Grammar: Verb Conjugations", "Compound Tenses", "Subjunctive Mood (Introduction)", "Conditional Tense", "Object Pronouns",
+    "Reflexive Verbs", "More Complex Sentence Structures", "Discussing Likes & Dislikes (Nuanced)", "Narrating Past Events", "Talking About Future Plans",
+    "Understanding News Headlines", "Reading Simple Articles", "Writing Short Essays", "Debating Simple Topics", "Idiomatic Expressions (Intermediate)",
+    "Advanced Grammar Review", "Complex Subjunctive Uses", "Passive Voice", "Discussing Abstract Concepts", "Advanced Conversation Practice" // Ensured 50 unique topics for the 50 lessons.
+  ];
+
+  for (let i = 0; i < lessonCount; i++) {
+    let title = `Lesson ${i + 1}: `;
+    let description = "";
+
+    // Use specific titles for first, second and last lesson as per example
+    if (i === 0) {
+        title = `Lesson 1: ${languageName === 'Spanish' ? 'Hola!' : languageName === 'French' ? 'Bonjour!' : 'Hallo!'} Basic Greetings`;
+        description = `Learn to say hello, goodbye, and introduce yourself in ${languageName}.`;
+    } else if (i === 1) {
+        title = `Lesson 2: Numbers 1-10 & ${languageName} Alphabet`;
+        description = `Mastering the ${languageName} alphabet and counting up to ten.`;
+    } else if (i === 49) { // Lesson 50 (index 49)
+        title = `Lesson 50: Advanced ${languageName} Conversation: Discussing Current Events`;
+        description = `Engage in complex discussions about news and global issues in ${languageName}.`;
+    } else {
+        // For other lessons, use the commonTopics array.
+        // Adjust index for topics because 0 and 1 are already handled.
+        // And topic for lesson 50 (index 49) is also handled.
+        // So, for i=2, use commonTopics[0] (adjusted)
+        // For i=48, use commonTopics[46] (adjusted)
+        let topicIndex = i - 2; // Initial offset
+        if (i > 40) { // Spread out remaining topics among lessons 41-49
+            topicIndex = 38 + (i-40) ; // Example: For i=41, topicIndex = 39. For i=48, topicIndex = 46
+        }
+        // Ensure topicIndex is within bounds of commonTopics for lessons 3 to 49
+        // commonTopics has 50 items.
+        // For i=2, use commonTopics[2] up to commonTopics[48] for i=48
+        if (i < commonTopics.length && i >=2) {
+             title += commonTopics[i]; // Use commonTopics[i] directly if i is a valid index after specific lessons
+             description = `Learn and practice ${commonTopics[i].toLowerCase()} in ${languageName}.`;
+        } else { // Fallback for any lessons not covered by specific titles or commonTopics indexing
+            title += `Topic ${i + 1}`;
+            description = `Explore topic ${i + 1} in ${languageName}.`;
+        }
+    }
+    lessons.push({ title, description });
+  }
+  return lessons;
+};
+
+export const languages: Language[] = [
+  {
+    name: "Spanish",
+    lessons: generateLessons("Spanish", 50),
+  },
+  {
+    name: "French",
+    lessons: generateLessons("French", 50),
+  },
+  {
+    name: "German",
+    lessons: generateLessons("German", 50),
+  },
+];


### PR DESCRIPTION
This commit introduces a new section to your dashboard for language learning.

Key changes:
- Added a data structure (`languageData.ts`) containing sample languages (Spanish, French, German) and 50 lessons for each, with titles and descriptions suggesting progressive difficulty.
- Modified the main dashboard page (`app/[locale]/dashboard/page.tsx`) to include:
    - A sidebar listing available languages.
    - A main content area displaying lessons for the selected language.
    - State management for selecting a language, defaulting to the first in the list.
- Applied basic styling using Tailwind CSS for the new components, including layout, hover/active states, and dark mode considerations.
- The new language learning section is displayed below the existing subscription and usage details and only appears for authenticated users with a subscription.

This lays the groundwork for future development of interactive lessons. The Vercel deployment issue regarding the root directory was also addressed by advising you to update your Vercel project settings.