### PR TITLE
I've just implemented a new feature that allows for post-call webhook…

### DIFF
--- a/poppa_frontend/src/app/api/elevenlabs-webhook/route.ts
+++ b/poppa_frontend/src/app/api/elevenlabs-webhook/route.ts
@@ -1,0 +1,128 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import supabaseClient from '@/lib/supabase'; // Import the Supabase client
+
+// Define the expected structure of the webhook payload (based on the issue description)
+interface ElevenLabsWebhookPayload {
+  type: string;
+  event_timestamp: number;
+  data: {
+    agent_id: string;
+    conversation_id: string;
+    status: string;
+    transcript: Array<{
+      role: string;
+      message: string;
+      // Add other transcript fields if needed
+    }>;
+    metadata: {
+      start_time_unix_secs: number;
+      call_duration_secs: number;
+      // Add other metadata fields if needed
+    };
+    analysis: {
+      transcript_summary?: string;
+      // Add other analysis fields if needed
+    };
+    conversation_initiation_client_data?: {
+      dynamic_variables?: {
+        user_id?: string;
+        target_language?: string;
+        // Add other dynamic variables if needed
+      };
+    };
+  };
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const payload = (await req.json()) as ElevenLabsWebhookPayload;
+
+    // Log the received payload for debugging (optional, remove in production if too verbose)
+    // console.log('Webhook payload received:', JSON.stringify(payload, null, 2));
+
+    // Validate payload structure (basic validation)
+    if (payload.type !== 'post_call_transcription' || !payload.data) {
+      console.error('Invalid payload type or missing data:', payload);
+      return NextResponse.json({ error: 'Invalid payload structure' }, { status: 400 });
+    }
+
+    const {
+      conversation_id,
+      transcript,
+      conversation_initiation_client_data,
+      // metadata, // if needed for credits, e.g., call_duration_secs
+    } = payload.data;
+
+    const userId = conversation_initiation_client_data?.dynamic_variables?.user_id;
+    const targetLanguage = conversation_initiation_client_data?.dynamic_variables?.target_language;
+
+    if (!userId) {
+      console.error('Missing user_id in dynamic_variables');
+      return NextResponse.json({ error: 'Missing user_id' }, { status: 400 });
+    }
+
+    if (!targetLanguage) {
+      console.error('Missing target_language in dynamic_variables');
+      // Depending on requirements, this might be optional or also return an error
+      // For now, let's log and proceed, or decide if it's critical
+    }
+
+    if (!conversation_id) {
+        console.error('Missing conversation_id in payload data');
+        return NextResponse.json({ error: 'Missing conversation_id' }, { status: 400 });
+    }
+
+    // 1. Decrement user credits (by incrementing usage)
+    // We'll increment usage by 1 for each call as per the plan.
+    const { error: usageError, data: usageData } = await supabaseClient.rpc('increment_user_usage', {
+      p_user_id: userId,
+      p_increment_by: 1,
+    });
+
+    if (usageError) {
+      console.error('Error incrementing user usage:', usageError);
+      // Decide if this is a fatal error. For now, let's assume it is.
+      return NextResponse.json({ error: 'Failed to update user usage' }, { status: 500 });
+    }
+    if (!usageData || usageData.length === 0) {
+        console.error('User usage not updated (user may not exist or RPC returned no data):', userId);
+        // This case might happen if increment_user_usage returns an empty set
+        return NextResponse.json({ error: 'Failed to update user usage, user not found or RPC error' }, { status: 404 });
+    }
+
+    // console.log('User usage updated:', usageData);
+
+    // 2. Store conversation transcript
+    // The 'conversation_transcripts' table will be created in the next step.
+    // For now, this code assumes it exists.
+    const { error: transcriptError } = await supabaseClient
+      .from('conversation_transcripts')
+      .insert({
+        user_id: userId,
+        target_language: targetLanguage, // This could be null if not provided
+        transcript: transcript, // Storing the full transcript array as JSONB
+        conversation_id: conversation_id, // Store the conversation_id
+        // created_at is handled by default value in the table schema
+      });
+
+    if (transcriptError) {
+      console.error('Error storing conversation transcript:', transcriptError);
+      // Decide if this is a fatal error.
+      return NextResponse.json({ error: 'Failed to store transcript' }, { status: 500 });
+    }
+
+    // console.log('Conversation transcript stored successfully for user:', userId);
+
+    return NextResponse.json({ message: 'Webhook received and processed successfully' }, { status: 200 });
+
+  } catch (error) {
+    console.error('Error processing webhook:', error);
+    if (error instanceof SyntaxError) {
+      return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 });
+    }
+    // General error
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: 'Internal Server Error', details: errorMessage }, { status: 500 });
+  }
+}

--- a/poppa_frontend/src/types/database.types.ts
+++ b/poppa_frontend/src/types/database.types.ts
@@ -9,6 +9,41 @@ export type Json =
 export type Database = {
   public: {
     Tables: {
+      conversation_transcripts: {
+        Row: {
+          id: number
+          user_id: string
+          conversation_id: string
+          target_language: string | null
+          transcript: Json | null // Assuming Json is already defined or Supabase handles it
+          created_at: string
+        }
+        Insert: {
+          id?: number
+          user_id: string
+          conversation_id: string
+          target_language?: string | null
+          transcript?: Json | null
+          created_at?: string
+        }
+        Update: {
+          id?: number
+          user_id?: string
+          conversation_id?: string
+          target_language?: string | null
+          transcript?: Json | null
+          created_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "conversation_transcripts_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       languages: {
         Row: {
           code: string

--- a/supabase/migrations/20240729000003_create_conversation_transcripts_table.sql
+++ b/supabase/migrations/20240729000003_create_conversation_transcripts_table.sql
@@ -1,0 +1,44 @@
+-- Create the conversation_transcripts table
+CREATE TABLE conversation_transcripts (
+    id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    user_id UUID REFERENCES auth.users(id) NOT NULL,
+    conversation_id TEXT NOT NULL UNIQUE,
+    target_language TEXT,
+    transcript JSONB,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
+);
+
+-- Add indexes for common query patterns
+CREATE INDEX IF NOT EXISTS idx_conversation_transcripts_user_id ON conversation_transcripts(user_id);
+CREATE INDEX IF NOT EXISTS idx_conversation_transcripts_conversation_id ON conversation_transcripts(conversation_id);
+CREATE INDEX IF NOT EXISTS idx_conversation_transcripts_target_language ON conversation_transcripts(target_language);
+
+-- Enable RLS
+ALTER TABLE conversation_transcripts ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies for conversation_transcripts
+
+-- Allow users to select their own transcripts
+CREATE POLICY "Allow users to select their own conversation transcripts"
+ON conversation_transcripts
+FOR SELECT
+USING (auth.uid() = user_id);
+
+-- Allow service_role to perform all operations (needed for the webhook to insert data)
+-- The webhook will call Supabase with the service_role key to bypass RLS for inserts.
+CREATE POLICY "Allow service_role to insert transcripts"
+ON conversation_transcripts
+FOR INSERT
+WITH CHECK (true); -- No specific check, service role has broad permissions
+
+-- Deny all other operations for other roles
+CREATE POLICY "Deny all other operations on conversation_transcripts"
+ON conversation_transcripts
+FOR ALL
+USING (false)
+WITH CHECK (false);
+
+-- Grant usage on the sequence for the id column to service_role if necessary, though GENERATED ALWAYS AS IDENTITY usually handles this.
+-- However, explicit grants can sometimes be needed depending on Supabase version or specific setups.
+-- For now, we assume default behavior is sufficient. If inserts fail due to permission on sequence, this might be needed:
+-- GRANT USAGE, SELECT ON SEQUENCE conversation_transcripts_id_seq TO service_role;


### PR DESCRIPTION
…s from ElevenLabs Conversational AI.

Here's a summary of what I did:
- I created a new API endpoint at `poppa_frontend/src/app/api/elevenlabs-webhook/route.ts`.
- This new endpoint is designed to process incoming information, specifically looking for your `user_id` and `target_language`.
- It will then update your usage count by one for each call.
- I've also set things up to store the conversation transcript, along with your `user_id`, `target_language`, and `conversation_id` in a new table called `conversation_transcripts`.
- To support this, I added a new database migration (`20240729000003_create_conversation_transcripts_table.sql`) to create the `conversation_transcripts` table with the necessary structure and security policies.
- I also updated `poppa_frontend/src/types/database.types.ts` to include the definition for this new table, which helps with type safety.

As per your initial request, this endpoint currently does not implement HMAC signature validation.