### PR TITLE
feat: Add HMAC signature verification to ElevenLabs webhook

### DIFF
--- a/poppa_frontend/src/app/api/elevenlabs-webhook/route.ts
+++ b/poppa_frontend/src/app/api/elevenlabs-webhook/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
-import supabaseClient from '@/lib/supabase'; // Import the Supabase client
+import crypto from 'crypto';
+import supabaseClient from '@/lib/supabase';
 
-// Define the expected structure of the webhook payload (based on the issue description)
+const elevenLabsWebhookSecret = process.env.ELEVENLABS_WEBHOOK_SECRET;
+
 interface ElevenLabsWebhookPayload {
   type: string;
   event_timestamp: number;
@@ -13,46 +15,68 @@ interface ElevenLabsWebhookPayload {
     transcript: Array<{
       role: string;
       message: string;
-      // Add other transcript fields if needed
+      time_in_call_secs?: number;
     }>;
     metadata: {
       start_time_unix_secs: number;
       call_duration_secs: number;
-      // Add other metadata fields if needed
     };
-    analysis: {
+    analysis?: {
       transcript_summary?: string;
-      // Add other analysis fields if needed
     };
     conversation_initiation_client_data?: {
       dynamic_variables?: {
         user_id?: string;
         target_language?: string;
-        // Add other dynamic variables if needed
       };
     };
   };
 }
 
+function verifySignature(rawBody: string, signature: string, secret: string): boolean {
+  const expectedSignature = crypto
+    .createHmac('sha256', secret)
+    .update(rawBody)
+    .digest('hex');
+
+  try {
+    return crypto.timingSafeEqual(
+      Buffer.from(signature),
+      Buffer.from(expectedSignature)
+    );
+  } catch {
+    return false;
+  }
+}
+
 export async function POST(req: NextRequest) {
   try {
-    const payload = (await req.json()) as ElevenLabsWebhookPayload;
+    const rawBody = await req.text();
 
-    // Log the received payload for debugging (optional, remove in production if too verbose)
-    // console.log('Webhook payload received:', JSON.stringify(payload, null, 2));
+    if (!elevenLabsWebhookSecret) {
+      console.error('ELEVENLABS_WEBHOOK_SECRET is not configured');
+      return NextResponse.json({ error: 'Webhook secret not configured' }, { status: 500 });
+    }
 
-    // Validate payload structure (basic validation)
+    const signature = req.headers.get('elevenlabs-signature');
+    if (!signature) {
+      console.error('Missing elevenlabs-signature header');
+      return NextResponse.json({ error: 'Missing signature' }, { status: 401 });
+    }
+
+    if (!verifySignature(rawBody, signature, elevenLabsWebhookSecret)) {
+      console.error('Invalid webhook signature');
+      return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
+    }
+
+    const payload = JSON.parse(rawBody) as ElevenLabsWebhookPayload;
+
     if (payload.type !== 'post_call_transcription' || !payload.data) {
       console.error('Invalid payload type or missing data:', payload);
       return NextResponse.json({ error: 'Invalid payload structure' }, { status: 400 });
     }
 
-    const {
-      conversation_id,
-      transcript,
-      conversation_initiation_client_data,
-      // metadata, // if needed for credits, e.g., call_duration_secs
-    } = payload.data;
+    const { conversation_id, transcript, conversation_initiation_client_data } = payload.data;
 
     const userId = conversation_initiation_client_data?.dynamic_variables?.user_id;
     const targetLanguage = conversation_initiation_client_data?.dynamic_variables?.target_language;
@@ -63,9 +87,7 @@ export async function POST(req: NextRequest) {
     }
 
     if (!targetLanguage) {
-      console.error('Missing target_language in dynamic_variables');
-      // Depending on requirements, this might be optional or also return an error
-      // For now, let's log and proceed, or decide if it's critical
+      console.warn('Missing target_language in dynamic_variables - proceeding without it');
     }
 
     if (!conversation_id) {
@@ -73,8 +95,6 @@ export async function POST(req: NextRequest) {
         return NextResponse.json({ error: 'Missing conversation_id' }, { status: 400 });
     }
 
-    // 1. Decrement user credits (by incrementing usage)
-    // We'll increment usage by 1 for each call as per the plan.
     const { error: usageError, data: usageData } = await supabaseClient.rpc('increment_user_usage', {
       p_user_id: userId,
       p_increment_by: 1,
@@ -82,39 +102,33 @@ export async function POST(req: NextRequest) {
 
     if (usageError) {
       console.error('Error incrementing user usage:', usageError);
-      // Decide if this is a fatal error. For now, let's assume it is.
       return NextResponse.json({ error: 'Failed to update user usage' }, { status: 500 });
     }
+
     if (!usageData || usageData.length === 0) {
-        console.error('User usage not updated (user may not exist or RPC returned no data):', userId);
-        // This case might happen if increment_user_usage returns an empty set
-        return NextResponse.json({ error: 'Failed to update user usage, user not found or RPC error' }, { status: 404 });
+      console.error('User not found in usage table:', userId);
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    // console.log('User usage updated:', usageData);
-
-    // 2. Store conversation transcript
-    // The 'conversation_transcripts' table will be created in the next step.
-    // For now, this code assumes it exists.
     const { error: transcriptError } = await supabaseClient
       .from('conversation_transcripts')
       .insert({
         user_id: userId,
-        target_language: targetLanguage, // This could be null if not provided
-        transcript: transcript, // Storing the full transcript array as JSONB
-        conversation_id: conversation_id, // Store the conversation_id
-        // created_at is handled by default value in the table schema
+        target_language: targetLanguage,
+        transcript: transcript,
+        conversation_id: conversation_id,
       });
 
     if (transcriptError) {
       console.error('Error storing conversation transcript:', transcriptError);
-      // Decide if this is a fatal error.
       return NextResponse.json({ error: 'Failed to store transcript' }, { status: 500 });
     }
 
-    // console.log('Conversation transcript stored successfully for user:', userId);
-
-    return NextResponse.json({ message: 'Webhook received and processed successfully' }, { status: 200 });
+    return NextResponse.json({
+      message: 'Transcript saved successfully',
+      conversation_id,
+      user_id: userId,
+    }, { status: 200 });
 
   } catch (error) {
     console.error('Error processing webhook:', error);


### PR DESCRIPTION
Add security hardening to the post_call_transcription webhook:
- Verify webhook signature using HMAC-SHA256 with timing-safe comparison
- Require ELEVENLABS_WEBHOOK_SECRET environment variable
- Return 401 for missing or invalid signatures
- Clean up verbose comments and improve error messages