### PR TITLE
fix: Move test files outside pages directory to fix build error

### DIFF
--- a/poppa_frontend/.eslintrc.json
+++ b/poppa_frontend/.eslintrc.json
@@ -238,6 +238,29 @@
   "overrides": [
     {
       "files": [
+        "src/pages/**/*.test.ts",
+        "src/pages/**/*.test.tsx",
+        "src/pages/**/*.spec.ts",
+        "src/pages/**/*.spec.tsx",
+        "src/pages/**/__tests__/**/*",
+        "src/app/**/*.test.ts",
+        "src/app/**/*.test.tsx",
+        "src/app/**/*.spec.ts",
+        "src/app/**/*.spec.tsx",
+        "src/app/**/__tests__/**/*"
+      ],
+      "rules": {
+        "no-restricted-syntax": [
+          "error",
+          {
+            "selector": "Program",
+            "message": "Test files must not be placed in src/pages/ or src/app/ directories. Move them to src/__tests__/ to prevent Next.js build errors."
+          }
+        ]
+      }
+    },
+    {
+      "files": [
         "**/__tests__/**/*",
         "**/*.test.ts",
         "**/*.test.tsx",

--- a/poppa_frontend/next.config.mjs
+++ b/poppa_frontend/next.config.mjs
@@ -6,11 +6,11 @@ const withNextIntl = createNextIntlPlugin();
 const nextConfig = {
   webpack(config) {
     config.module.rules.push({
-      test: /\.svg$/, // Look for .svg files
-      use: ["@svgr/webpack"], // Use @svgr/webpack to handle them
+      test: /\.svg$/,
+      use: ["@svgr/webpack"],
     });
 
-    return config; // Always return the modified config
+    return config;
   },
 };
 

--- a/poppa_frontend/src/__tests__/api/elevenlabs/webhooks.test.ts
+++ b/poppa_frontend/src/__tests__/api/elevenlabs/webhooks.test.ts
@@ -4,7 +4,6 @@ import { buffer } from "micro";
 import { createMocks } from "node-mocks-http";
 
 import supabaseClient from "@/lib/supabase";
-
 import elevenlabsWebhookHandler from "@/pages/api/elevenlabs/webhooks";
 
 import type { NextApiRequest, NextApiResponse } from "next";

--- a/poppa_frontend/src/__tests__/api/elevenlabs/webhooks.test.ts
+++ b/poppa_frontend/src/__tests__/api/elevenlabs/webhooks.test.ts
@@ -5,7 +5,7 @@ import { createMocks } from "node-mocks-http";
 
 import supabaseClient from "@/lib/supabase";
 
-import elevenlabsWebhookHandler from "../webhooks";
+import elevenlabsWebhookHandler from "@/pages/api/elevenlabs/webhooks";
 
 import type { NextApiRequest, NextApiResponse } from "next";
 import type { MockRequest, MockResponse } from "node-mocks-http";

--- a/poppa_frontend/src/__tests__/api/stripe/checkout-session.test.ts
+++ b/poppa_frontend/src/__tests__/api/stripe/checkout-session.test.ts
@@ -3,7 +3,7 @@ import Stripe from "stripe";
 
 import supabaseClient from "@/lib/supabase";
 
-import checkoutSessionHandler from "../checkout-session";
+import checkoutSessionHandler from "@/pages/api/stripe/checkout-session";
 
 import type { NextApiRequest, NextApiResponse } from "next";
 import type { MockRequest, MockResponse } from "node-mocks-http";

--- a/poppa_frontend/src/__tests__/api/stripe/checkout-session.test.ts
+++ b/poppa_frontend/src/__tests__/api/stripe/checkout-session.test.ts
@@ -2,7 +2,6 @@ import { createMocks } from "node-mocks-http";
 import Stripe from "stripe";
 
 import supabaseClient from "@/lib/supabase";
-
 import checkoutSessionHandler from "@/pages/api/stripe/checkout-session";
 
 import type { NextApiRequest, NextApiResponse } from "next";

--- a/poppa_frontend/src/__tests__/api/stripe/customer-portal.test.ts
+++ b/poppa_frontend/src/__tests__/api/stripe/customer-portal.test.ts
@@ -2,7 +2,6 @@ import { createMocks } from "node-mocks-http";
 import Stripe from "stripe";
 
 import supabaseClient from "@/lib/supabase";
-
 import customerPortalHandler from "@/pages/api/stripe/customer-portal";
 
 import type { NextApiRequest, NextApiResponse } from "next";

--- a/poppa_frontend/src/__tests__/api/stripe/customer-portal.test.ts
+++ b/poppa_frontend/src/__tests__/api/stripe/customer-portal.test.ts
@@ -3,7 +3,7 @@ import Stripe from "stripe";
 
 import supabaseClient from "@/lib/supabase";
 
-import customerPortalHandler from "../customer-portal";
+import customerPortalHandler from "@/pages/api/stripe/customer-portal";
 
 import type { NextApiRequest, NextApiResponse } from "next";
 import type { MockRequest, MockResponse } from "node-mocks-http";

--- a/poppa_frontend/src/__tests__/api/stripe/webhooks.test.ts
+++ b/poppa_frontend/src/__tests__/api/stripe/webhooks.test.ts
@@ -3,7 +3,6 @@ import { createMocks } from "node-mocks-http";
 import Stripe from "stripe";
 
 import supabaseClient from "@/lib/supabase";
-
 import stripeWebhookHandler from "@/pages/api/stripe/webhooks";
 
 import type { NextApiRequest, NextApiResponse } from "next";

--- a/poppa_frontend/src/__tests__/api/stripe/webhooks.test.ts
+++ b/poppa_frontend/src/__tests__/api/stripe/webhooks.test.ts
@@ -4,7 +4,7 @@ import Stripe from "stripe";
 
 import supabaseClient from "@/lib/supabase";
 
-import stripeWebhookHandler from "../webhooks";
+import stripeWebhookHandler from "@/pages/api/stripe/webhooks";
 
 import type { NextApiRequest, NextApiResponse } from "next";
 import type { MockRequest, MockResponse } from "node-mocks-http";


### PR DESCRIPTION
Test files in pages/api/ were being included in the Next.js build,
causing a syntax error when process.env.NEXT_PUBLIC_* variables were
replaced with string literals at build time, resulting in invalid
assignment expressions like "price_placeholder" = "value".

Moved test files from pages/api/__tests__/ to src/__tests__/api/ and
updated their imports to use the @/ path alias.