### PR TITLE
Fix linting, formatting, and type checking

### DIFF
--- a/poppa_frontend/src/i18n/__tests__/middleware-sync.test.ts
+++ b/poppa_frontend/src/i18n/__tests__/middleware-sync.test.ts
@@ -1,5 +1,7 @@
-import { routing } from "../routing";
 import { config } from "../../middleware";
+import { routing } from "../routing";
+
+type Locale = (typeof routing.locales)[number];
 
 describe("middleware i18n configuration", () => {
   it("should have a matcher pattern that includes all routing locales", () => {
@@ -17,14 +19,12 @@ describe("middleware i18n configuration", () => {
     const matcherLocales = new Set(match![1].split("|"));
 
     // Check that all routing locales are in the matcher
-    const missingFromMatcher = [...routingLocales].filter(
-      (locale) => !matcherLocales.has(locale)
-    );
+    const missingFromMatcher = [...routingLocales].filter((locale) => !matcherLocales.has(locale));
     expect(missingFromMatcher).toEqual([]);
 
     // Check that all matcher locales are in routing (no stale locales)
     const extraInMatcher = [...matcherLocales].filter(
-      (locale) => !routingLocales.has(locale)
+      (locale) => !routingLocales.has(locale as Locale)
     );
     expect(extraInMatcher).toEqual([]);
   });


### PR DESCRIPTION
- Reorder imports to satisfy eslint import/order rule
- Add Locale type to fix TypeScript type error in routingLocales.has()
- Apply Prettier formatting

## Summary

<!-- Provide a brief description of the changes in this PR -->

## Related Issue

<!-- Link to any related issues: Fixes #123, Relates to #456 -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

<!-- Describe the specific changes made in this PR -->

-
-
-

## Voice-Only Compliance

<!-- Confirm this PR respects the voice-only philosophy -->

- [ ] This PR does not introduce text-based learning features
- [ ] This PR maintains the minimal UI principle
- [ ] N/A - This PR does not affect the learning interface

## Testing Done

<!-- Describe the testing you've performed -->

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Tested on mobile viewport
- [ ] Tested voice interaction (if applicable)

## Test Commands Run

```bash
pnpm lint       # ✅ / ❌
pnpm typecheck  # ✅ / ❌
pnpm test       # ✅ / ❌
pnpm build      # ✅ / ❌
```

## Screenshots

<!-- If UI changes, include before/after screenshots -->

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] All imports use `@/*` path aliases
- [ ] Client components have `"use client"` directive
- [ ] User-facing text uses `next-intl` translations
- [ ] I have added tests for my changes
- [ ] All new and existing tests pass
- [ ] I have updated documentation as needed

## Additional Notes

<!-- Any additional information reviewers should know -->
